### PR TITLE
204: Fix Nullpointer when deleting a replaying session

### DIFF
--- a/ui-core/src/main/java/ch/adv/ui/core/logic/EventManager.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/logic/EventManager.java
@@ -103,8 +103,13 @@ public class EventManager {
      */
     public void fire(ADVEvent event, Object oldVal, Object newVal,
                      String... filterArgs) {
-        String handle = event.toString() + String.join("-", filterArgs);
+        String handle = event.toString();
         eventStore.firePropertyChange(handle, oldVal, newVal);
         logger.debug("Fired event {}", handle);
+        if (filterArgs.length > 0) {
+            handle += String.join("-", filterArgs);
+            eventStore.firePropertyChange(handle, oldVal, newVal);
+            logger.debug("Fired event {}", handle);
+        }
     }
 }

--- a/ui-core/src/main/java/ch/adv/ui/core/logic/SessionStore.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/logic/SessionStore.java
@@ -144,7 +144,7 @@ public class SessionStore {
             logger.info("Session {} deleted from SessionStore", id);
         }
         logger.debug("Fire change event");
-        eventManager.fire(ADVEvent.SESSION_REMOVED, existing, null);
+        eventManager.fire(ADVEvent.SESSION_REMOVED, existing, null, id+"");
     }
 
     /**

--- a/ui-core/src/main/java/ch/adv/ui/core/logic/SessionStore.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/logic/SessionStore.java
@@ -144,7 +144,7 @@ public class SessionStore {
             logger.info("Session {} deleted from SessionStore", id);
         }
         logger.debug("Fire change event");
-        eventManager.fire(ADVEvent.SESSION_REMOVED, existing, null, id+"");
+        eventManager.fire(ADVEvent.SESSION_REMOVED, existing, null, id + "");
     }
 
     /**

--- a/ui-core/src/main/java/ch/adv/ui/core/presentation/SessionReplay.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/presentation/SessionReplay.java
@@ -1,11 +1,15 @@
 package ch.adv.ui.core.presentation;
 
+import ch.adv.ui.core.logic.ADVEvent;
+import ch.adv.ui.core.logic.EventManager;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
 import javafx.application.Platform;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.util.TimerTask;
 
 
@@ -20,14 +24,23 @@ public class SessionReplay extends TimerTask {
             .getLogger(SessionReplay.class);
     private final StateViewModel stateViewModel;
     private final SteppingViewModel steppingViewModel;
+    private final EventManager eventManager;
+    private final DeleteSessionChangeListener listener;
+    private final long sessionId;
     private boolean isCanceled;
 
     @Inject
     public SessionReplay(@Assisted StateViewModel stateViewModel,
-                         @Assisted SteppingViewModel steppingViewModel) {
-
+                         @Assisted SteppingViewModel steppingViewModel,
+                         EventManager eventManager) {
+        logger.debug("Initialize RessionReplay");
         this.stateViewModel = stateViewModel;
         this.steppingViewModel = steppingViewModel;
+        this.eventManager = eventManager;
+        this.listener = new SessionReplay.DeleteSessionChangeListener();
+        this.sessionId = stateViewModel.getSessionId();
+        eventManager
+                .subscribe(listener, ADVEvent.SESSION_REMOVED, sessionId + "");
         if (stateViewModel.getCurrentSnapshotIndex() == stateViewModel
                 .getMaxSnapshotIndex()) {
             steppingViewModel.navigateSnapshot(Navigate.FIRST);
@@ -58,6 +71,9 @@ public class SessionReplay extends TimerTask {
      * taking place.
      */
     private boolean cancelReplay() {
+        eventManager
+                .unsubscribe(listener, ADVEvent.SESSION_REMOVED,
+                        sessionId + "");
         Platform.runLater(
                 () -> stateViewModel.getReplayingProperty().set(false)
         );
@@ -67,5 +83,18 @@ public class SessionReplay extends TimerTask {
     public boolean isCanceled() {
         return isCanceled;
     }
+
+    /**
+     * Listen for deleted session
+     */
+    private class DeleteSessionChangeListener implements
+            PropertyChangeListener {
+
+        @Override
+        public void propertyChange(PropertyChangeEvent event) {
+            cancelReplay();
+        }
+    }
+
 }
 

--- a/ui-core/src/main/java/ch/adv/ui/core/presentation/SessionReplay.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/presentation/SessionReplay.java
@@ -39,8 +39,8 @@ public class SessionReplay extends TimerTask {
         this.eventManager = eventManager;
         this.listener = new SessionReplay.DeleteSessionChangeListener();
         this.sessionId = stateViewModel.getSessionId();
-        eventManager
-                .subscribe(listener, ADVEvent.SESSION_REMOVED, sessionId + "");
+        eventManager.subscribe(listener,
+                ADVEvent.SESSION_REMOVED, sessionId + "");
         if (stateViewModel.getCurrentSnapshotIndex() == stateViewModel
                 .getMaxSnapshotIndex()) {
             steppingViewModel.navigateSnapshot(Navigate.FIRST);
@@ -71,9 +71,8 @@ public class SessionReplay extends TimerTask {
      * taking place.
      */
     private boolean cancelReplay() {
-        eventManager
-                .unsubscribe(listener, ADVEvent.SESSION_REMOVED,
-                        sessionId + "");
+        eventManager.unsubscribe(
+                listener, ADVEvent.SESSION_REMOVED, sessionId + "");
         Platform.runLater(
                 () -> stateViewModel.getReplayingProperty().set(false)
         );

--- a/ui-core/src/main/java/ch/adv/ui/core/presentation/SteppingViewModel.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/presentation/SteppingViewModel.java
@@ -6,6 +6,8 @@ import ch.adv.ui.core.logic.LayoutedSnapshotStore;
 import ch.adv.ui.core.logic.domain.LayoutedSnapshot;
 import com.google.inject.Inject;
 import com.google.inject.assistedinject.Assisted;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Handles stepping logic for the
@@ -15,6 +17,9 @@ public class SteppingViewModel {
     private final EventManager eventManager;
     private final LayoutedSnapshotStore layoutedSnapshotStore;
     private StateViewModel stateViewModel;
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(SteppingViewModel.class);
 
     @Inject
     public SteppingViewModel(LayoutedSnapshotStore layoutedSnapshotStore,
@@ -75,6 +80,8 @@ public class SteppingViewModel {
 
 
     private void fireEvent(ADVEvent event, int oldIndex, int newIndex) {
+        logger.debug(layoutedSnapshotStore+"");
+        logger.debug(stateViewModel+"");
         LayoutedSnapshot oldLayoutedSnapshot = layoutedSnapshotStore
                 .getAll(stateViewModel.getSessionId())
                 .get(oldIndex);

--- a/ui-core/src/main/java/ch/adv/ui/core/presentation/SteppingViewModel.java
+++ b/ui-core/src/main/java/ch/adv/ui/core/presentation/SteppingViewModel.java
@@ -14,12 +14,11 @@ import org.slf4j.LoggerFactory;
  * {@link ch.adv.ui.core.presentation.SessionView}.
  */
 public class SteppingViewModel {
+    private static final Logger logger = LoggerFactory
+            .getLogger(SteppingViewModel.class);
     private final EventManager eventManager;
     private final LayoutedSnapshotStore layoutedSnapshotStore;
     private StateViewModel stateViewModel;
-
-    private static final Logger logger = LoggerFactory
-            .getLogger(SteppingViewModel.class);
 
     @Inject
     public SteppingViewModel(LayoutedSnapshotStore layoutedSnapshotStore,
@@ -80,8 +79,8 @@ public class SteppingViewModel {
 
 
     private void fireEvent(ADVEvent event, int oldIndex, int newIndex) {
-        logger.debug(layoutedSnapshotStore+"");
-        logger.debug(stateViewModel+"");
+        logger.debug(layoutedSnapshotStore + "");
+        logger.debug(stateViewModel + "");
         LayoutedSnapshot oldLayoutedSnapshot = layoutedSnapshotStore
                 .getAll(stateViewModel.getSessionId())
                 .get(oldIndex);

--- a/ui-core/src/test/java/ch/adv/ui/core/logic/EventManagerTest.java
+++ b/ui-core/src/test/java/ch/adv/ui/core/logic/EventManagerTest.java
@@ -80,12 +80,24 @@ public class EventManagerTest {
     }
 
     @Test
-    public void receiveNoChangeEvent() {
-        long sessionId = 123789;
+    public void receiveNotifyForUniversalListener() {
+        long sessionId = 42;
 
         eventManagerUnterTest.subscribe(listenerTest, ADVEvent.SNAPSHOT_ADDED);
         eventManagerUnterTest.fire(ADVEvent.SNAPSHOT_ADDED, null, null,
                 sessionId + "");
+
+        Mockito.verify(listenerTest).propertyChange(any());
+    }
+
+    @Test
+    public void receiveNoChangeEvent() {
+        long sessionIdListened = 42;
+        long sessionIdIgnored = 123789;
+
+        eventManagerUnterTest.subscribe(listenerTest, ADVEvent.SNAPSHOT_ADDED, sessionIdListened+"");
+        eventManagerUnterTest.fire(ADVEvent.SNAPSHOT_ADDED, null, null,
+                sessionIdIgnored + "");
 
         Mockito.verify(listenerTest, never()).propertyChange(any());
     }


### PR DESCRIPTION
fix fire event: subscrber without args should be notified when event with args is fired
fix rootviewModel: since it handles deleting sessions itself, it does not need to be notified about deleted sessions